### PR TITLE
MPI_Init: Update to return success if already initialized

### DIFF
--- a/ompi/mpi/c/Makefile.am
+++ b/ompi/mpi/c/Makefile.am
@@ -434,7 +434,8 @@ libmpi_c_mpi_la_SOURCES = \
         win_test.c \
         win_unlock.c \
 	win_unlock_all.c \
-        win_wait.c
+        win_wait.c \
+        mpi_api_pvars.c
 
 
 if OMPI_ENABLE_MPI1_COMPAT

--- a/ompi/mpi/c/allreduce.c
+++ b/ompi/mpi/c/allreduce.c
@@ -33,6 +33,8 @@
 #include "ompi/memchecker.h"
 #include "ompi/runtime/ompi_spc.h"
 
+#include "ompi/mpi/c/mpi_api_pvars.h"
+
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
 #pragma weak MPI_Allreduce = PMPI_Allreduce
@@ -47,6 +49,9 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
                   MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
 {
     int err;
+
+    /* Count same params */
+    MPI_API_PVARS_ALL_REDUCE_SAME_PARAMS_COUNT(sendbuf, recvbuf, count);
 
     SPC_RECORD(OMPI_SPC_ALLREDUCE, 1);
 

--- a/ompi/mpi/c/bcast.c
+++ b/ompi/mpi/c/bcast.c
@@ -27,6 +27,7 @@
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
 #include "ompi/runtime/ompi_spc.h"
+#include "ompi/mpi/c/mpi_api_pvars.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -42,6 +43,9 @@ int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype,
               int root, MPI_Comm comm)
 {
     int err;
+
+    /* Log last buffer used */
+    MPI_API_PVARS_BCAST_LAST_BUFFER_USED(buffer);
 
     SPC_RECORD(OMPI_SPC_BCAST, 1);
 

--- a/ompi/mpi/c/gatherv.c
+++ b/ompi/mpi/c/gatherv.c
@@ -31,6 +31,7 @@
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
 #include "ompi/runtime/ompi_spc.h"
+#include "ompi/mpi/c/mpi_api_pvars.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -47,6 +48,9 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
     int i, size, err;
+
+    /* Log last buffer send size used */
+    MPI_API_PVARS_GATHERV_LAST_SEND_SIZE_USED(sendcount);
 
     SPC_RECORD(OMPI_SPC_GATHERV, 1);
 

--- a/ompi/mpi/c/init.c
+++ b/ompi/mpi/c/init.c
@@ -49,6 +49,14 @@ int MPI_Init(int *argc, char ***argv)
     int provided;
     char *env;
     int required = MPI_THREAD_SINGLE;
+    int ret;
+    int is_initialized;
+
+    /* Don't re-initialize MPI if already iniitalized */
+    ret = MPI_Initialized(&is_initialized);
+    if (is_initialized) {
+        return MPI_SUCCESS;
+    }
 
     /* check for environment overrides for required thread level.  If
        there is, check to see that it is a valid/supported thread level.

--- a/ompi/mpi/c/init.c
+++ b/ompi/mpi/c/init.c
@@ -31,6 +31,8 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/constants.h"
 
+#include "ompi/mpi/c/mpi_api_pvars.h"
+
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
 #pragma weak MPI_Init = PMPI_Init
@@ -85,6 +87,11 @@ int MPI_Init(int *argc, char ***argv)
     OPAL_CR_INIT_LIBRARY();
 
     SPC_INIT();
+
+#if defined(MPI_API_PVARS_ENABLE)
+    /* Initialize MPI API PVARs */
+    mpi_api_pvars_init();
+#endif
 
     return MPI_SUCCESS;
 }

--- a/ompi/mpi/c/irecv.c
+++ b/ompi/mpi/c/irecv.c
@@ -28,6 +28,7 @@
 #include "ompi/request/request.h"
 #include "ompi/memchecker.h"
 #include "ompi/runtime/ompi_spc.h"
+#include "ompi/mpi/c/mpi_api_pvars.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -43,6 +44,9 @@ int MPI_Irecv(void *buf, int count, MPI_Datatype type, int source,
               int tag, MPI_Comm comm, MPI_Request *request)
 {
     int rc = MPI_SUCCESS;
+
+    /* Count P2P local/remote */
+    MPI_API_PVARS_P2P_LOCAL_REMOTE_COUNT(source, comm);
 
     SPC_RECORD(OMPI_SPC_IRECV, 1);
 

--- a/ompi/mpi/c/isend.c
+++ b/ompi/mpi/c/isend.c
@@ -32,6 +32,7 @@
 #include "ompi/request/request.h"
 #include "ompi/memchecker.h"
 #include "ompi/runtime/ompi_spc.h"
+#include "ompi/mpi/c/mpi_api_pvars.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -47,6 +48,9 @@ int MPI_Isend(const void *buf, int count, MPI_Datatype type, int dest,
               int tag, MPI_Comm comm, MPI_Request *request)
 {
     int rc = MPI_SUCCESS;
+
+    /* Count P2P local/remote */
+    MPI_API_PVARS_P2P_LOCAL_REMOTE_COUNT(dest, comm);
 
     SPC_RECORD(OMPI_SPC_ISEND, 1);
 

--- a/ompi/mpi/c/mpi_api_pvars.c
+++ b/ompi/mpi/c/mpi_api_pvars.c
@@ -46,6 +46,36 @@ int mpi_api_pvars_init(void)
                                 MCA_BASE_PVAR_FLAG_READONLY | MCA_BASE_PVAR_FLAG_CONTINUOUS,
                                 NULL, NULL, NULL, (void *)&ompi_api_pvars.reduce_same_recvbuf_cnt);
 
+   ret = mca_base_pvar_register(project, framework, component,
+                                "p2p_to_local_rank_cnt", "Number of times P2P communications API functions called with local process/rank",
+                                OPAL_INFO_LVL_3, MCA_BASE_PVAR_CLASS_SIZE,
+                                MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, MCA_BASE_VAR_BIND_NO_OBJECT,
+                                MCA_BASE_PVAR_FLAG_READONLY | MCA_BASE_PVAR_FLAG_CONTINUOUS,
+                                NULL, NULL, NULL, (void *)&ompi_api_pvars.p2p_to_local_rank_cnt);
+
+   ret = mca_base_pvar_register(project, framework, component,
+                                "p2p_to_remote_rank_cnt", "Number of times P2P communications API functions called with remote process/rank",
+                                OPAL_INFO_LVL_3, MCA_BASE_PVAR_CLASS_SIZE,
+                                MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, MCA_BASE_VAR_BIND_NO_OBJECT,
+                                MCA_BASE_PVAR_FLAG_READONLY | MCA_BASE_PVAR_FLAG_CONTINUOUS,
+                                NULL, NULL, NULL, (void *)&ompi_api_pvars.p2p_to_remote_rank_cnt);
+
+   ret = mca_base_pvar_register(project, framework, component,
+                                "bcast_last_buffer_ptr_used", "Last buffer used by MPI_Bcast() - For preparing histogram",
+                                OPAL_INFO_LVL_3, MCA_BASE_PVAR_CLASS_SIZE,
+                                MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, MCA_BASE_VAR_BIND_NO_OBJECT,
+                                MCA_BASE_PVAR_FLAG_READONLY | MCA_BASE_PVAR_FLAG_CONTINUOUS,
+                                NULL, NULL, NULL, (void *)&ompi_api_pvars.bcast_last_buffer_ptr_used);
+
+
+   ret = mca_base_pvar_register(project, framework, component,
+                                "gatherv_last_send_size_used", "Last send size used by MPI_Gatherv(), variadic size - For preparing histogram",
+                                OPAL_INFO_LVL_3, MCA_BASE_PVAR_CLASS_SIZE,
+                                MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, MCA_BASE_VAR_BIND_NO_OBJECT,
+                                MCA_BASE_PVAR_FLAG_READONLY | MCA_BASE_PVAR_FLAG_CONTINUOUS,
+                                NULL, NULL, NULL, (void *)&ompi_api_pvars.gatherv_last_send_size_used);
+
+
    return OPAL_SUCCESS;
 }
 

--- a/ompi/mpi/c/mpi_api_pvars.c
+++ b/ompi/mpi/c/mpi_api_pvars.c
@@ -1,0 +1,51 @@
+/**
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
+*/
+
+#include "ompi/mpi/c/mpi_api_pvars.h"
+
+/* PVARs structure */
+ompi_api_pvars_t ompi_api_pvars;
+
+int mpi_api_pvars_init(void)
+{
+   const char *project = "ompi";
+   const char *framework = "ompi";
+   const char *component = "mpi_api";
+   int ret;
+
+   /* Zero all counters */
+   memset(&ompi_api_pvars, 0x00, sizeof(ompi_api_pvars));
+
+   /* register performance variables */
+   ret = mca_base_pvar_register(project, framework, component, 
+                                "allreduce_same_sendbuf", "Number of times MPI_Allreduce() was called with the same sendbuf consecutively",
+                                OPAL_INFO_LVL_3, MCA_BASE_PVAR_CLASS_SIZE,
+                                MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, MCA_BASE_VAR_BIND_NO_OBJECT,
+                                MCA_BASE_PVAR_FLAG_READONLY | MCA_BASE_PVAR_FLAG_CONTINUOUS,
+                                NULL, NULL, NULL, (void *)&ompi_api_pvars.allreduce_same_sendbuf_cnt);
+
+   ret = mca_base_pvar_register(project, framework, component,
+                                "allreduce_same_recvbuf", "Number of times MPI_Allreduce() was called with the same recvbuf consecutively",
+                                OPAL_INFO_LVL_3, MCA_BASE_PVAR_CLASS_SIZE,
+                                MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, MCA_BASE_VAR_BIND_NO_OBJECT,
+                                MCA_BASE_PVAR_FLAG_READONLY | MCA_BASE_PVAR_FLAG_CONTINUOUS,
+                                NULL, NULL, NULL, (void *)&ompi_api_pvars.allreduce_same_recvbuf_cnt);
+
+   ret = mca_base_pvar_register(project, framework, component, 
+                                "reduce_same_sendbuf", "Number of times MPI_Reduce() was called with the same sendbuf consecutively",
+                                OPAL_INFO_LVL_3, MCA_BASE_PVAR_CLASS_SIZE,
+                                MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, MCA_BASE_VAR_BIND_NO_OBJECT,
+                                MCA_BASE_PVAR_FLAG_READONLY | MCA_BASE_PVAR_FLAG_CONTINUOUS,
+                                NULL, NULL, NULL, (void *)&ompi_api_pvars.reduce_same_sendbuf_cnt);
+
+   ret = mca_base_pvar_register(project, framework, component,
+                                "reduce_same_recvbuf", "Number of times MPI_Reduce() was called with the same recvbuf consecutively",
+                                OPAL_INFO_LVL_3, MCA_BASE_PVAR_CLASS_SIZE,
+                                MCA_BASE_VAR_TYPE_UNSIGNED_LONG, NULL, MCA_BASE_VAR_BIND_NO_OBJECT,
+                                MCA_BASE_PVAR_FLAG_READONLY | MCA_BASE_PVAR_FLAG_CONTINUOUS,
+                                NULL, NULL, NULL, (void *)&ompi_api_pvars.reduce_same_recvbuf_cnt);
+
+   return OPAL_SUCCESS;
+}
+

--- a/ompi/mpi/c/mpi_api_pvars.h
+++ b/ompi/mpi/c/mpi_api_pvars.h
@@ -9,6 +9,7 @@
 #include "ompi/runtime/params.h"
 #include "opal/mca/timer/timer.h"
 #include "opal/mca/base/mca_base_pvar.h"
+#include "opal/mca/hwloc/hwloc-internal.h"
 
 /* Enables MPI API PVARs */
 #define MPI_API_PVARS_ENABLE
@@ -35,6 +36,18 @@ typedef struct ompi_api_pvars_s {
 
    /* Counts the number of consecutive MPI_Reduce() calls with the same recvbuf and count */
    volatile opal_atomic_size_t reduce_same_recvbuf_cnt;
+
+   /* Counts the number of local ranks in P2P communication API function calls */
+   volatile opal_atomic_size_t p2p_to_local_rank_cnt;
+
+   /* Counts the number of remote ranks in P2P communication API function calls */
+   volatile opal_atomic_size_t p2p_to_remote_rank_cnt;
+
+   /* Last buffer used by MPI_Bcast() - For preparing histogram */
+   volatile opal_atomic_size_t bcast_last_buffer_ptr_used;
+
+   /* Last send size used by MPI_Gatherv(), variadic size - For preparing histogram */
+   volatile opal_atomic_size_t gatherv_last_send_size_used;
 
 } ompi_api_pvars_t;
 
@@ -78,10 +91,46 @@ typedef opal_atomic_size_t ompi_spc_value_t;
 	prev_recvbuf = recvbuf;\
 	prev_count = count;
 
+/*
+   Count P2P local/remote
+   P2P: MPI_Send(), MPI_Isend(), MPI_Recv(), MPI_Irecv()
+*/
+#define MPI_API_PVARS_P2P_LOCAL_REMOTE_COUNT(rank_idx, comm) {\
+		struct ompi_proc_t *rank_iter =\
+            (struct ompi_proc_t*)ompi_comm_peer_lookup(comm, rank_idx);\
+        if (OPAL_PROC_ON_LOCAL_SOCKET(rank_iter->super.proc_flags)) {\
+		   ompi_api_pvars.p2p_to_local_rank_cnt++; /* UCG_GROUP_MEMBER_DISTANCE_SOCKET */ \
+		} else if (OPAL_PROC_ON_LOCAL_HOST(rank_iter->super.proc_flags)) {\
+		   ompi_api_pvars.p2p_to_remote_rank_cnt++; /* UCG_GROUP_MEMBER_DISTANCE_HOST */ \
+		} else /* UCG_GROUP_MEMBER_DISTANCE_NET */ \
+		    ompi_api_pvars.p2p_to_remote_rank_cnt++;\
+}
+
+/*
+   MPI_Bcast() buffers used for trace (for histogram)
+*/
+#define MPI_API_PVARS_BCAST_LAST_BUFFER_USED(buffer) \
+		ompi_api_pvars.bcast_last_buffer_ptr_used = (uintptr_t)buffer;
+
+/*
+   MPI_Gatherv() - Used sizes for trace
+*/
+#define MPI_API_PVARS_GATHERV_LAST_SEND_SIZE_USED(size) \
+		ompi_api_pvars.gatherv_last_send_size_used = size;
+
+
 #else
+
 #define MPI_API_PVARS_ALL_REDUCE_SAME_PARAMS_COUNT(sendbuf, recvbuf, count)
 
 #define MPI_API_PVARS_REDUCE_SAME_PARAMS_COUNT(sendbuf, recvbuf, count)
+
+MPI_API_PVARS_P2P_LOCAL_REMOTE_COUNT(source, comm)
+
+#define MPI_API_PVARS_BCAST_LAST_BUFFER_USED(buffer)
+
+#define MPI_API_PVARS_GATHERV_LAST_SEND_SIZE_USED(size)
+
 #endif /* MPI_API_PVARS_ENABLE */
 
 /* Initialize collecting MPI API PVARs */

--- a/ompi/mpi/c/mpi_api_pvars.h
+++ b/ompi/mpi/c/mpi_api_pvars.h
@@ -1,0 +1,90 @@
+/**
+* Copyright (C) Huawei Technologies Co., Ltd. 2020.  ALL RIGHTS RESERVED.
+*/
+
+#if !defined(_MPI_API_PVARS_H_)
+#define _MPI_API_PVARS_H_
+
+#include "ompi/datatype/ompi_datatype.h"
+#include "ompi/runtime/params.h"
+#include "opal/mca/timer/timer.h"
+#include "opal/mca/base/mca_base_pvar.h"
+
+/* Enables MPI API PVARs */
+#define MPI_API_PVARS_ENABLE
+
+/* Enables MPI API PVARs debug prints */
+//#define MPI_T_API_PVARS_DEBUG_ENABLE
+
+#if defined(MPI_T_API_PVARS_DEBUG_ENABLE)
+#define MPI_T_API_PVARS_DEBUG_PRINT printf
+#else
+#define MPI_T_API_PVARS_DEBUG_PRINT
+#endif
+
+/* A structure for the OMPI API PVARs */
+typedef struct ompi_api_pvars_s {
+   /* Counts the number of consecutive MPI_Allreduce() calls with the same sendbuf and count */
+   volatile opal_atomic_size_t allreduce_same_sendbuf_cnt;
+
+   /* Counts the number of consecutive MPI_Allreduce() calls with the same recvbuf and count */
+   volatile opal_atomic_size_t allreduce_same_recvbuf_cnt;
+
+   /* Counts the number of consecutive MPI_Reduce() calls with the same sendbuf and count */
+   volatile opal_atomic_size_t reduce_same_sendbuf_cnt;
+
+   /* Counts the number of consecutive MPI_Reduce() calls with the same recvbuf and count */
+   volatile opal_atomic_size_t reduce_same_recvbuf_cnt;
+
+} ompi_api_pvars_t;
+
+/* Instantiation of the OMPI API PVARs object */
+extern ompi_api_pvars_t ompi_api_pvars;
+
+typedef opal_atomic_size_t ompi_spc_value_t;
+
+#if defined(MPI_API_PVARS_ENABLE)
+/*(void)opal_atomic_fetch_add_size_t(&ompi_api_pvars.allreduce_same_params_cnt, 1);*/
+/* MPI_Allreduce: Count same params */
+#define MPI_API_PVARS_ALL_REDUCE_SAME_PARAMS_COUNT(sendbuf, recvbuf, count)\
+	static const void *prev_sendbuf = NULL;\
+	static void *prev_recvbuf = NULL;\
+	static int prev_count = 0;\
+	MPI_T_API_PVARS_DEBUG_PRINT("ALLREDUCE: %p %p %d, %lu, %lu\n", sendbuf, recvbuf, count, ompi_api_pvars.allreduce_same_sendbuf_cnt, ompi_api_pvars.allreduce_same_recvbuf_cnt);\
+	if (count == prev_count) {\
+		if (sendbuf == prev_sendbuf)\
+		   ompi_api_pvars.allreduce_same_sendbuf_cnt++;\
+	    if (recvbuf == prev_recvbuf)\
+	       ompi_api_pvars.allreduce_same_recvbuf_cnt++;\
+	}\
+	prev_sendbuf = sendbuf;\
+	prev_recvbuf = recvbuf;\
+	prev_count = count;
+
+
+/* MPI_Reduce: Count same params */
+#define MPI_API_PVARS_REDUCE_SAME_PARAMS_COUNT(sendbuf, recvbuf, count)\
+	static const void *prev_sendbuf = NULL;\
+	static void *prev_recvbuf = NULL;\
+	static int prev_count = 0;\
+	MPI_T_API_PVARS_DEBUG_PRINT("REDUCE: %p %p %d, %lu, %lu\n", sendbuf, recvbuf, count, ompi_api_pvars.reduce_same_sendbuf_cnt, ompi_api_pvars.reduce_same_recvbuf_cnt);\
+	if (count == prev_count) {\
+		if (sendbuf == prev_sendbuf)\
+		   ompi_api_pvars.reduce_same_sendbuf_cnt++;\
+		if (recvbuf == prev_recvbuf)\
+		   ompi_api_pvars.reduce_same_recvbuf_cnt++;\
+	}\
+	prev_sendbuf = sendbuf;\
+	prev_recvbuf = recvbuf;\
+	prev_count = count;
+
+#else
+#define MPI_API_PVARS_ALL_REDUCE_SAME_PARAMS_COUNT(sendbuf, recvbuf, count)
+
+#define MPI_API_PVARS_REDUCE_SAME_PARAMS_COUNT(sendbuf, recvbuf, count)
+#endif /* MPI_API_PVARS_ENABLE */
+
+/* Initialize collecting MPI API PVARs */
+int mpi_api_pvars_init(void);
+
+#endif /* _MPI_API_PVARS_H_ */

--- a/ompi/mpi/c/profile/Makefile.am
+++ b/ompi/mpi/c/profile/Makefile.am
@@ -414,7 +414,8 @@ nodist_libmpi_c_pmpi_la_SOURCES = \
         pwin_test.c \
         pwin_unlock.c \
 	pwin_unlock_all.c \
-        pwin_wait.c
+        pwin_wait.c \
+        pmpi_api_pvars.c
 
 if OMPI_ENABLE_MPI1_COMPAT
 nodist_libmpi_c_pmpi_la_SOURCES += \

--- a/ompi/mpi/c/recv.c
+++ b/ompi/mpi/c/recv.c
@@ -28,6 +28,7 @@
 #include "ompi/memchecker.h"
 #include "ompi/request/request.h"
 #include "ompi/runtime/ompi_spc.h"
+#include "ompi/mpi/c/mpi_api_pvars.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -43,6 +44,9 @@ int MPI_Recv(void *buf, int count, MPI_Datatype type, int source,
              int tag, MPI_Comm comm, MPI_Status *status)
 {
     int rc = MPI_SUCCESS;
+
+    /* Count P2P local/remote */
+    MPI_API_PVARS_P2P_LOCAL_REMOTE_COUNT(source, comm);
 
     SPC_RECORD(OMPI_SPC_RECV, 1);
 

--- a/ompi/mpi/c/reduce.c
+++ b/ompi/mpi/c/reduce.c
@@ -33,6 +33,8 @@
 #include "ompi/memchecker.h"
 #include "ompi/runtime/ompi_spc.h"
 
+#include "ompi/mpi/c/mpi_api_pvars.h"
+
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
 #pragma weak MPI_Reduce = PMPI_Reduce
@@ -47,6 +49,9 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
                MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm)
 {
     int err;
+
+    /* Count same params */
+    MPI_API_PVARS_REDUCE_SAME_PARAMS_COUNT(sendbuf, recvbuf, count);
 
     SPC_RECORD(OMPI_SPC_REDUCE, 1);
 

--- a/ompi/mpi/c/send.c
+++ b/ompi/mpi/c/send.c
@@ -31,6 +31,7 @@
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/memchecker.h"
 #include "ompi/runtime/ompi_spc.h"
+#include "ompi/mpi/c/mpi_api_pvars.h"
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
@@ -46,6 +47,9 @@ int MPI_Send(const void *buf, int count, MPI_Datatype type, int dest,
              int tag, MPI_Comm comm)
 {
     int rc = MPI_SUCCESS;
+
+    /* Count P2P local/remote */
+    MPI_API_PVARS_P2P_LOCAL_REMOTE_COUNT(dest, comm);
 
     SPC_RECORD(OMPI_SPC_SEND, 1);
 


### PR DESCRIPTION
- The reason for this is to support multiple calls to MPI_Init().
- Required in the case where a Score-P plugin is required to initialize
  MPI even before the Score-P framework executed the application.